### PR TITLE
feat: integrate Neon database branching for PR previews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,7 +156,8 @@ jobs:
         id: deploy
         run: |
           url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} \
-            --env DATABASE_URL="${{ steps.neon-db.outputs.database_url }}")
+            --env DATABASE_URL="${{ steps.neon-db.outputs.database_url }}" \
+            --env NEXTAUTH_URL="https://${{ env.PREVIEW_DOMAIN }}")
           echo "preview-url=$url" >> $GITHUB_OUTPUT
 
       - name: Add Stable Preview Alias
@@ -258,6 +259,8 @@ jobs:
         env:
           BASE_URL: ${{ needs.deploy-preview.outputs.stable-url }}
           DATABASE_URL: ${{ steps.neon-db.outputs.database_url }}
+          NEXTAUTH_URL: ${{ needs.deploy-preview.outputs.stable-url }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           CI: true
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

Integrates Neon database branching with GitHub Actions to provide isolated database environments for each PR.

## How It Works

```
PR Opened/Updated
    │
    ▼
┌─────────────────────────┐
│ Create Database Branch  │ ← Creates pr-{number}-{branch-name}
│ (Neon branch action)    │
└───────────┬─────────────┘
            │
            ▼
┌─────────────────────────┐
│ Deploy Preview          │ ← Pushes schema, deploys with branch DB
│ (Vercel with branch DB) │
└───────────┬─────────────┘
            │
            ▼
┌─────────────────────────┐
│ E2E Tests (Preview)     │ ← Creates test users in branch DB
│ (Same branch DB)        │
└───────────┬─────────────┘
            │
PR Closed   │
    │       │
    ▼       ▼
┌─────────────────────────┐
│ Delete Database Branch  │ ← Cleans up branch
└─────────────────────────┘
```

## Changes

- **`create-neon-branch` job**: Creates a Neon database branch when PR is opened
- **`deploy-preview` job**: Uses branch DATABASE_URL for schema push and deployment
- **`e2e-preview` job**: Uses same branch DATABASE_URL for dynamic test users
- **`delete-neon-branch` job**: Deletes branch when PR is closed

## Benefits

- Each PR gets an isolated database branch
- E2E tests create/cleanup users in the same database the preview uses
- No test data pollution in production database
- Automatic cleanup when PR is closed

## Test plan

- [ ] PR creates a Neon branch
- [ ] Preview deployment uses the branch database
- [ ] E2E tests create dynamic users in branch database
- [ ] E2E tests pass against preview
- [ ] PR close deletes the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)