### PR TITLE
test: verify Neon database branching setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, reopened, closed]
 
 # Stable preview domain for OAuth callbacks
+# Neon database branching managed via GitHub Actions (not Vercel integration)
 env:
   PREVIEW_DOMAIN: holiday-heroes-preview.vercel.app
 


### PR DESCRIPTION
## Summary
This PR verifies the Neon database branching pipeline works correctly after disabling the Vercel integration.

## What to Verify
- [ ] `Create Database Branch` job creates `pr-219` branch in Neon
- [ ] `Deploy Preview` job deploys with the branch DATABASE_URL
- [ ] `E2E Tests` pass against the preview with isolated database
- [ ] After merge/close, `Delete Database Branch` cleans up `pr-219`

## Changes
- Added comment clarifying Neon branching is managed via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)